### PR TITLE
Refactored TideTimes view and view model to optionally fetch the weather info

### DIFF
--- a/TideApp/TideApp.xcodeproj/project.pbxproj
+++ b/TideApp/TideApp.xcodeproj/project.pbxproj
@@ -74,6 +74,9 @@
 		914C91442652C6F100D16031 /* SearchControllerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914C91432652C6F100D16031 /* SearchControllerProvider.swift */; };
 		914C914A2652C70C00D16031 /* ViewControllerResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914C91492652C70C00D16031 /* ViewControllerResolver.swift */; };
 		91AAFC4B264D6EAB00E8A76E /* LocationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91AAFC4A264D6EAB00E8A76E /* LocationsView.swift */; };
+		91BA455726554A010072755D /* TideTimesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91BA455626554A010072755D /* TideTimesViewModel.swift */; };
+		91BA455E26554AFA0072755D /* TideTimesInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91BA455D26554AFA0072755D /* TideTimesInfoView.swift */; };
+		91BA456526554CD60072755D /* SearchResultButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91BA456426554CD60072755D /* SearchResultButton.swift */; };
 		91F7CFB326550FAB0013DFCC /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91F7CFB226550FAB0013DFCC /* NetworkManager.swift */; };
 		91F7CFB926550FF40013DFCC /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91F7CFB826550FF40013DFCC /* NetworkError.swift */; };
 		91F7CFBF265510010013DFCC /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91F7CFBE265510010013DFCC /* HTTPMethod.swift */; };
@@ -196,6 +199,9 @@
 		914C91432652C6F100D16031 /* SearchControllerProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchControllerProvider.swift; sourceTree = "<group>"; };
 		914C91492652C70C00D16031 /* ViewControllerResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerResolver.swift; sourceTree = "<group>"; };
 		91AAFC4A264D6EAB00E8A76E /* LocationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationsView.swift; sourceTree = "<group>"; };
+		91BA455626554A010072755D /* TideTimesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TideTimesViewModel.swift; sourceTree = "<group>"; };
+		91BA455D26554AFA0072755D /* TideTimesInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TideTimesInfoView.swift; sourceTree = "<group>"; };
+		91BA456426554CD60072755D /* SearchResultButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultButton.swift; sourceTree = "<group>"; };
 		91F7CFB226550FAB0013DFCC /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		91F7CFB826550FF40013DFCC /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		91F7CFBE265510010013DFCC /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
@@ -412,6 +418,8 @@
 			isa = PBXGroup;
 			children = (
 				36D4BE7626443336005CA64F /* TideTimesView.swift */,
+				91BA455626554A010072755D /* TideTimesViewModel.swift */,
+				91BA455D26554AFA0072755D /* TideTimesInfoView.swift */,
 			);
 			path = TideTimesView;
 			sourceTree = "<group>";
@@ -530,6 +538,7 @@
 				914C91372652B84200D16031 /* SearchView.swift */,
 				914C913D2652C67E00D16031 /* SearchViewModel.swift */,
 				914C91432652C6F100D16031 /* SearchControllerProvider.swift */,
+				91BA456426554CD60072755D /* SearchResultButton.swift */,
 			);
 			path = SearchView;
 			sourceTree = "<group>";
@@ -812,11 +821,13 @@
 			files = (
 				36D04EAB2645499C006EB2DC /* TideAppApp.swift in Sources */,
 				909BA5DD26417C48000FFBD5 /* AppDelegate.swift in Sources */,
+				91BA455E26554AFA0072755D /* TideTimesInfoView.swift in Sources */,
 				12266B8C264BE59A00DE7FCA /* UserLocator.swift in Sources */,
 				12FE3E8D2642B719000F7476 /* WeatherResponse.swift in Sources */,
 				909BA5CD264171E1000FFBD5 /* AppConfig.swift in Sources */,
 				91F7CFB926550FF40013DFCC /* NetworkError.swift in Sources */,
 				90F7124826494BB8002642DE /* TideAppWidget.intentdefinition in Sources */,
+				91BA456526554CD60072755D /* SearchResultButton.swift in Sources */,
 				911E7B75264ECC1E0000BC15 /* LocationButton.swift in Sources */,
 				91F7CFC52655102D0013DFCC /* RequestType.swift in Sources */,
 				911E7B56264EC91A0000BC15 /* WeatherInfo.swift in Sources */,
@@ -827,6 +838,7 @@
 				91F7CFB326550FAB0013DFCC /* NetworkManager.swift in Sources */,
 				36D04EAD264567EB006EB2DC /* Date+String.swift in Sources */,
 				12266B86264BE04A00DE7FCA /* CLLocationManager+Publisher.swift in Sources */,
+				91BA455726554A010072755D /* TideTimesViewModel.swift in Sources */,
 				36D04EA926453521006EB2DC /* Date+Helpers.swift in Sources */,
 				36D4BE7126443305005CA64F /* StylesheetComponentExample.swift in Sources */,
 				91F7CFD62655113A0013DFCC /* GetWeatherInformationRequest.swift in Sources */,

--- a/TideApp/TideApp/Scenes/LocationsView/LocationButton.swift
+++ b/TideApp/TideApp/Scenes/LocationsView/LocationButton.swift
@@ -42,7 +42,7 @@ struct LocationButton: View {
     .accentColor(.primaryActionColor)
     .background(Rectangle().shadow(radius: 4))
     .sheet(isPresented: $showSheet, content: {
-      TideTimesView(weatherInfo: weatherInfo)
+      TideTimesView(viewModel: TideTimesLocalViewModel(weatherInfo: weatherInfo))
     })
   }
 }

--- a/TideApp/TideApp/Scenes/SearchView/SearchResultButton.swift
+++ b/TideApp/TideApp/Scenes/SearchView/SearchResultButton.swift
@@ -1,0 +1,36 @@
+//
+//  SearchResultButton.swift
+//  TideApp
+//
+//  Created by John Sanderson on 19/05/2021.
+//
+
+import SwiftUI
+import MapKit
+
+struct SearchResultButton: View {
+
+  let placemark: MKPlacemark
+  @State private var showSheet = false
+
+  var body: some View {
+    Button(action: {
+      showSheet.toggle()
+    }) {
+      VStack(alignment: .leading, spacing: PaddingValues.tiny) {
+        SubtitleLabel(text: placemark.name ?? "")
+        BodyLabel(text: placemark.title ?? "")
+      }
+      .padding(PaddingValues.small)
+    }
+    .sheet(isPresented: $showSheet, content: {
+      TideTimesView(viewModel: TideTimesNetworkViewModel(location: placemark.location))
+    })
+  }
+}
+
+struct SearchResultButton_Previews: PreviewProvider {
+  static var previews: some View {
+    SearchResultButton(placemark: MKPlacemark())
+  }
+}

--- a/TideApp/TideApp/Scenes/SearchView/SearchView.swift
+++ b/TideApp/TideApp/Scenes/SearchView/SearchView.swift
@@ -74,15 +74,7 @@ private struct ResultsView: View {
 
   var body: some View {
     List {
-      ForEach(results, id: \.self) { placemark in
-        Button(action: {}) {
-          VStack(alignment: .leading, spacing: PaddingValues.tiny) {
-            SubtitleLabel(text: placemark.name ?? "")
-            BodyLabel(text: placemark.title ?? "")
-          }
-          .padding(PaddingValues.small)
-        }
-      }
+      ForEach(results, id: \.self, content: SearchResultButton.init)
     }
   }
 }

--- a/TideApp/TideApp/Scenes/TideTimesView/TideTimesInfoView.swift
+++ b/TideApp/TideApp/Scenes/TideTimesView/TideTimesInfoView.swift
@@ -1,0 +1,48 @@
+//
+//  TideTimesInfoView.swift
+//  TideApp
+//
+//  Created by John Sanderson on 19/05/2021.
+//
+
+import SwiftUI
+
+struct TideTimesInfoView: View {
+  
+  let weatherInfo: WeatherInfo
+
+  var body: some View {
+    ScrollView(.vertical, showsIndicators: false, content: {
+      VStack(alignment: .leading, spacing: nil, content: {
+        TitleLabel(text: weatherInfo.locationName)
+          .accessibility(label: Text("You are looking at tide times for \(weatherInfo.locationName)"))
+          .padding([.bottom, .top], PaddingValues.medium)
+        SubtitleLabel(text: weatherInfo.subTitle)
+          .padding(.bottom, PaddingValues.tiny)
+        if let tideStatus = weatherInfo.tideTimes.current?.tideType.description.full {
+          BodyLabel(text: tideStatus)
+            .padding(.bottom, PaddingValues.tiny)
+        }
+        ForEach(weatherInfo.tideTimes) { tideTime in
+          BodyLabel(text: "\(tideTime.tideType.rawValue.capitalized): \(tideTime.tideTime)")
+        }
+        if let tideHeight = weatherInfo.tideHeight {
+          SubtitleLabel(text: tideHeight)
+            .padding([.bottom, .top], PaddingValues.small)
+        }
+        if let waterTemperature = weatherInfo.waterTemperature {
+          SubtitleLabel(text: waterTemperature)
+            .padding([.bottom, .top], PaddingValues.small)
+        }
+      })
+      .padding([.leading, .trailing], PaddingValues.medium)
+    })
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+  }
+}
+
+struct TideTimesInfoView_Previews: PreviewProvider {
+    static var previews: some View {
+      TideTimesInfoView(weatherInfo: .init(locationName: "Brighton", subTitle: "Tide times", tideTimes: [], tideHeight: nil, waterTemperature: nil))
+    }
+}

--- a/TideApp/TideApp/Scenes/TideTimesView/TideTimesView.swift
+++ b/TideApp/TideApp/Scenes/TideTimesView/TideTimesView.swift
@@ -9,42 +9,33 @@ import SwiftUI
 import Combine
 import CoreLocation
 
-struct TideTimesView: View {
+struct TideTimesView<ViewModel: TideTimesViewModelType>: View {
 
-  let weatherInfo: WeatherInfo
+  @ObservedObject var viewModel: ViewModel
 
   var body: some View {
-    ScrollView(.vertical, showsIndicators: false, content: {
-      VStack(alignment: .leading, spacing: nil, content: {
-        TitleLabel(text: weatherInfo.locationName)
-          .accessibility(label: Text("You are looking at tide times for \(weatherInfo.locationName)"))
-          .padding([.bottom, .top], PaddingValues.medium)
-        SubtitleLabel(text: weatherInfo.subTitle)
-          .padding(.bottom, PaddingValues.tiny)
-        if let tideStatus = weatherInfo.tideTimes.current?.tideType.description.full {
-          BodyLabel(text: tideStatus)
-            .padding(.bottom, PaddingValues.tiny)
-        }
-        ForEach(weatherInfo.tideTimes) { tideTime in
-          BodyLabel(text: "\(tideTime.tideType.rawValue.capitalized): \(tideTime.tideTime)")
-        }
-        if let tideHeight = weatherInfo.tideHeight {
-          SubtitleLabel(text: tideHeight)
-            .padding([.bottom, .top], PaddingValues.small)
-        }
-        if let waterTemperature = weatherInfo.waterTemperature {
-          SubtitleLabel(text: waterTemperature)
-            .padding([.bottom, .top], PaddingValues.small)
-        }
-      })
-      .padding([.leading, .trailing], PaddingValues.medium)
-    })
-    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    makeView(for: viewModel.state)
+      .background(Color.backgroundColor.ignoresSafeArea(.all, edges: [.top, .bottom]))
+      .onAppear { viewModel.getTideTimes() }
+  }
+
+  private func makeView(for state: TideTimesState) -> AnyView {
+    switch viewModel.state {
+    case .idle:
+      return AnyView(Color.backgroundColor)
+    case .loading:
+      return AnyView(TitleLabel(text: "Loading..."))
+    case .error(let error):
+      return AnyView(ErrorView(error: error, buttonAction: { viewModel.getTideTimes() }))
+    case .success(let info):
+      return AnyView(TideTimesInfoView(weatherInfo: info))
+    }
   }
 }
 
 struct TideTimesView_Previews: PreviewProvider {
   static var previews: some View {
-    TideTimesView(weatherInfo: .init(locationName: "Brighton", subTitle: "Tide times", tideTimes: [], tideHeight: nil, waterTemperature: nil))
+    let viewModel = TideTimesLocalViewModel(weatherInfo: .init(locationName: "Brighton", subTitle: "Tide times", tideTimes: [], tideHeight: nil, waterTemperature: nil))
+    return TideTimesView(viewModel: viewModel)
   }
 }

--- a/TideApp/TideApp/Scenes/TideTimesView/TideTimesViewModel.swift
+++ b/TideApp/TideApp/Scenes/TideTimesView/TideTimesViewModel.swift
@@ -1,0 +1,95 @@
+//
+//  TideTimesViewModel.swift
+//  TideApp
+//
+//  Created by John Sanderson on 19/05/2021.
+//
+
+import Foundation
+import Combine
+import CoreLocation
+
+enum TideTimesState {
+  case idle
+  case loading
+  case error(Error)
+  case success(WeatherInfo)
+}
+
+protocol TideTimesViewModelType: ObservableObject {
+
+  var state: TideTimesState { get }
+
+  func getTideTimes()
+}
+
+// MARK: - Network ViewModel -
+
+/// A `TideTimesViewModelType` that fetches the `WeatherInfo` from the network using the provided location
+final class TideTimesNetworkViewModel: TideTimesViewModelType {
+
+  // MARK: - Properties -
+  // MARK: Internal
+
+  @Published var state: TideTimesState = .idle
+
+  // MARK: Private
+
+  private let location: CLLocation?
+  private let networkManager: NetworkManagerType
+  private var cancellable: AnyCancellable?
+
+  // MARK: - Initialiser -
+
+  init(location: CLLocation?, networkManager: NetworkManagerType = NetworkManager()) {
+    self.location = location
+    self.networkManager = networkManager
+  }
+
+  // MARK: - Functions -
+  // MARK: Internal
+
+  func getTideTimes() {
+    state = .loading
+    guard let location = location else {
+      state = .error(WeatherError.parsing(description: "Invalid location"))
+      return
+    }
+    let request = GetWeatherInformationRequest(location: location, date: Date(), networkManager: networkManager)
+    cancellable = request.perform()
+      .sink(receiveCompletion: { completion in
+        guard case let .failure(error) = completion else { return }
+        self.state = .error(error)
+      }, receiveValue: {
+        self.state = .success($0)
+      })
+  }
+}
+
+// MARK: - Local ViewModel -
+
+/// A `TideTimesViewModelType` that is initialised directly with a `WeatherInfo` object
+final class TideTimesLocalViewModel: TideTimesViewModelType {
+
+  // MARK: - Properties -
+  // MARK: Internal
+
+  @Published var state: TideTimesState = .idle
+
+  // MARK: Private
+
+  private let weatherInfo: WeatherInfo
+
+  // MARK: - Initialiser -
+
+  init(weatherInfo: WeatherInfo) {
+    self.weatherInfo = weatherInfo
+  }
+
+  // MARK: - Functions -
+  // MARK: Internal
+
+  func getTideTimes() {
+    state = .success(weatherInfo)
+  }
+}


### PR DESCRIPTION
`TideTimesViewModel` is now hidden behind a protocol. 

The `TideTimesLocalViewModel` is initialised directly with a `WeatherInfo` object and is used when choosing a location from the home view. 

The `TideTimesNetworkViewModel` is initialised with a `CLLocation` and fetches the `WeatherInfo` from the network. This is used when selecting a search result. 